### PR TITLE
🔒 [security fix] Protect API routes in middleware

### DIFF
--- a/scripts/test-middleware.js
+++ b/scripts/test-middleware.js
@@ -63,9 +63,11 @@ const tests = [
 
   // Boundary condition tests: paths that should NOT be confused with /api or /api/auth
   { pathname: '/apiary', session: null, isValid: false, expected: { type: 'redirect', url: '/login' } },
+  { pathname: '/apiary', session: 'val', isValid: true, expected: { type: 'next' } },
   { pathname: '/api/authors', session: null, isValid: false, expected: { type: 'json', status: 401, error: 'Unauthorized' } },
   { pathname: '/api/authors', session: 'val', isValid: true, expected: { type: 'next' } },
   { pathname: '/login-page', session: null, isValid: false, expected: { type: 'redirect', url: '/login' } },
+  { pathname: '/login-page', session: 'val', isValid: true, expected: { type: 'next' } },
 ];
 
 tests.forEach((test, index) => {

--- a/scripts/test-middleware.js
+++ b/scripts/test-middleware.js
@@ -1,0 +1,98 @@
+const assert = require('assert');
+
+// Mocking the logic in middleware.ts
+function simulateMiddleware(pathname, session, isValidSession) {
+  const isApiRoute = pathname.startsWith('/api');
+  const isAuthRoute = pathname.startsWith('/login') || pathname.startsWith('/api/auth');
+
+  // 1. Handle protected routes
+  if (!isAuthRoute) {
+    if (!session) {
+      if (isApiRoute) {
+        return { type: 'json', status: 401, error: 'Unauthorized' };
+      }
+      return { type: 'redirect', url: '/login' };
+    }
+
+    const isValid = isValidSession;
+    if (!isValid) {
+      if (isApiRoute) {
+        return { type: 'json', status: 401, error: 'Unauthorized' };
+      }
+      return { type: 'redirect', url: '/login', deleteSession: true };
+    }
+  }
+
+  // 2. Handle login page redirect if already authenticated
+  if (pathname.startsWith('/login') && session) {
+    const isValid = isValidSession;
+    if (isValid) {
+      return { type: 'redirect', url: '/' };
+    }
+  }
+
+  return { type: 'next' };
+}
+
+// Test cases
+const tests = [
+  // Public UI routes
+  { pathname: '/login', session: null, isValid: false, expected: { type: 'next' } },
+  { pathname: '/login', session: 'val', isValid: true, expected: { type: 'redirect', url: '/' } },
+
+  // Public API routes
+  { pathname: '/api/auth/session', session: null, isValid: false, expected: { type: 'next' } },
+  { pathname: '/api/auth/session', session: 'val', isValid: true, expected: { type: 'next' } },
+
+  // Protected UI routes
+  { pathname: '/', session: null, isValid: false, expected: { type: 'redirect', url: '/login' } },
+  { pathname: '/dashboard', session: 'val', isValid: true, expected: { type: 'next' } },
+  { pathname: '/dashboard', session: 'val', isValid: false, expected: { type: 'redirect', url: '/login', deleteSession: true } },
+
+  // Protected API routes
+  { pathname: '/api/data', session: null, isValid: false, expected: { type: 'json', status: 401, error: 'Unauthorized' } },
+  { pathname: '/api/data', session: 'val', isValid: true, expected: { type: 'next' } },
+  { pathname: '/api/data', session: 'val', isValid: false, expected: { type: 'json', status: 401, error: 'Unauthorized' } },
+];
+
+tests.forEach((test, index) => {
+  const result = simulateMiddleware(test.pathname, test.session, test.isValid);
+  try {
+    assert.deepStrictEqual(result, test.expected);
+    console.log(`Test ${index + 1} passed: ${test.pathname} (session: ${test.session})`);
+  } catch (err) {
+    console.error(`Test ${index + 1} failed: ${test.pathname}`);
+    console.error(`  Expected: `, test.expected);
+    console.error(`  Actual:   `, result);
+    process.exit(1);
+  }
+});
+
+console.log('All middleware logic tests passed!');
+
+// Regex test
+// Next.js matcher '/((?!_next/static|_next/image|favicon.ico).*)'
+// matches everything except those prefixes.
+const regex = /^\/(?!(_next\/static|_next\/image|favicon\.ico)).*/;
+
+const matcherTests = [
+    { path: '/api/data', match: true },
+    { path: '/api/auth/session', match: true },
+    { path: '/_next/static/main.js', match: false },
+    { path: '/_next/image/photo.jpg', match: false },
+    { path: '/favicon.ico', match: false },
+    { path: '/', match: true },
+    { path: '/login', match: true },
+];
+
+matcherTests.forEach((test, index) => {
+    const isMatch = regex.test(test.path);
+    if (isMatch !== test.match) {
+        console.error(`Matcher Test ${index + 1} failed for ${test.path}. Expected match: ${test.match}, Got: ${isMatch}`);
+        process.exit(1);
+    } else {
+        console.log(`Matcher Test ${index + 1} passed: ${test.path}`);
+    }
+});
+
+console.log('All matcher tests passed!');

--- a/scripts/test-middleware.js
+++ b/scripts/test-middleware.js
@@ -1,9 +1,16 @@
 const assert = require('assert');
 
+// Helper function to match exact path or path prefix with trailing slash
+function matchesExactOrPrefix(pathname, path) {
+  return pathname === path || pathname.startsWith(path + '/');
+}
+
 // Mocking the logic in middleware.ts
 function simulateMiddleware(pathname, session, isValidSession) {
-  const isApiRoute = pathname === '/api' || pathname.startsWith('/api/');
-  const isAuthRoute = pathname === '/login' || pathname.startsWith('/login/') || pathname === '/api/auth' || pathname.startsWith('/api/auth/');
+  const isApiRoute = matchesExactOrPrefix(pathname, '/api');
+  const isLoginRoute = matchesExactOrPrefix(pathname, '/login');
+  const isApiAuthRoute = matchesExactOrPrefix(pathname, '/api/auth');
+  const isAuthRoute = isLoginRoute || isApiAuthRoute;
 
   // 1. Handle protected routes
   if (!isAuthRoute) {
@@ -24,7 +31,7 @@ function simulateMiddleware(pathname, session, isValidSession) {
   }
 
   // 2. Handle login page redirect if already authenticated
-  if ((pathname === '/login' || pathname.startsWith('/login/')) && session) {
+  if (isLoginRoute && session) {
     const isValid = isValidSession;
     if (isValid) {
       return { type: 'redirect', url: '/' };

--- a/scripts/test-middleware.js
+++ b/scripts/test-middleware.js
@@ -2,8 +2,8 @@ const assert = require('assert');
 
 // Mocking the logic in middleware.ts
 function simulateMiddleware(pathname, session, isValidSession) {
-  const isApiRoute = pathname.startsWith('/api');
-  const isAuthRoute = pathname.startsWith('/login') || pathname.startsWith('/api/auth');
+  const isApiRoute = pathname === '/api' || pathname.startsWith('/api/');
+  const isAuthRoute = pathname === '/login' || pathname.startsWith('/login/') || pathname === '/api/auth' || pathname.startsWith('/api/auth/');
 
   // 1. Handle protected routes
   if (!isAuthRoute) {
@@ -24,7 +24,7 @@ function simulateMiddleware(pathname, session, isValidSession) {
   }
 
   // 2. Handle login page redirect if already authenticated
-  if (pathname.startsWith('/login') && session) {
+  if ((pathname === '/login' || pathname.startsWith('/login/')) && session) {
     const isValid = isValidSession;
     if (isValid) {
       return { type: 'redirect', url: '/' };
@@ -53,6 +53,12 @@ const tests = [
   { pathname: '/api/data', session: null, isValid: false, expected: { type: 'json', status: 401, error: 'Unauthorized' } },
   { pathname: '/api/data', session: 'val', isValid: true, expected: { type: 'next' } },
   { pathname: '/api/data', session: 'val', isValid: false, expected: { type: 'json', status: 401, error: 'Unauthorized' } },
+
+  // Boundary condition tests: paths that should NOT be confused with /api or /api/auth
+  { pathname: '/apiary', session: null, isValid: false, expected: { type: 'redirect', url: '/login' } },
+  { pathname: '/api/authors', session: null, isValid: false, expected: { type: 'json', status: 401, error: 'Unauthorized' } },
+  { pathname: '/api/authors', session: 'val', isValid: true, expected: { type: 'next' } },
+  { pathname: '/login-page', session: null, isValid: false, expected: { type: 'redirect', url: '/login' } },
 ];
 
 tests.forEach((test, index) => {


### PR DESCRIPTION
🎯 **What:** Fixed an insecure middleware configuration that explicitly bypassed all `/api` routes.

⚠️ **Risk:** All backend API endpoints were unprotected by the session verification logic, potentially allowing unauthorized users to access or manipulate data via current or future API routes.

🛡️ **Solution:** 
1. Updated `config.matcher` in `src/middleware.ts` to include `/api` routes in the middleware processing.
2. Modified the `middleware` function to:
    - Enforce session verification for all `/api` routes, excluding authentication-related endpoints under `/api/auth`.
    - Return a `401 Unauthorized` JSON response for unauthenticated API requests, ensuring correct behavior for programmatic clients.
    - Maintain existing redirect behavior for UI-based routes.
    - Correctly handle public routes like `/login` and `/api/auth/*`.

Verification:
- Created and ran `scripts/test-middleware.js` to simulate various request scenarios (UI vs API, authenticated vs unauthenticated, public vs protected).
- Verified that `/api/auth/session` remains accessible for login/logout.
- Verified that other `/api/*` routes return 401 when no session is present.
- Verified that UI routes still redirect to `/login` when unauthorized.

---
*PR created automatically by Jules for task [15807149381290739031](https://jules.google.com/task/15807149381290739031) started by @thoreinstein*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * API endpoints now return proper 401 JSON errors for unauthorized requests instead of redirects.
  * Protected UI routes redirect unauthenticated users to the login page and clear invalid sessions.
  * Access control and session validation behavior refined across routes, including auto-redirect from login for authenticated users.

* **Tests**
  * Added a self-contained test harness to simulate and validate middleware access-control and route-matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->